### PR TITLE
feat: add basic browse/search, categories and pagination

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -22,54 +22,63 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 # In-memory activity database
 activities = {
     "Chess Club": {
+        "category": "Clubs",
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
         "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
     },
     "Programming Class": {
+        "category": "Classes",
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
     "Gym Class": {
+        "category": "Classes",
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
     "Soccer Team": {
+        "category": "Teams",
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
         "participants": ["liam@mergington.edu", "noah@mergington.edu"]
     },
     "Basketball Team": {
+        "category": "Teams",
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
         "participants": ["ava@mergington.edu", "mia@mergington.edu"]
     },
     "Art Club": {
+        "category": "Clubs",
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
         "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
     },
     "Drama Club": {
+        "category": "Clubs",
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
         "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
     },
     "Math Club": {
+        "category": "Clubs",
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
         "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
     },
     "Debate Team": {
+        "category": "Teams",
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
@@ -84,8 +93,66 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(q: str = None, category: str = None, page: int = 1, size: int = 5, sort: str = "name"):
+    """Return paginated, searchable list of activities.
+
+    Query params:
+    - q: search term for name/description
+    - category: filter by category
+    - page: page number (1-based)
+    - size: page size
+    - sort: currently supports 'name' or 'spots'
+    """
+
+    # Build list of activity objects
+    items = []
+    for name, details in activities.items():
+        item = dict(name=name, **details)
+        # compute spots left
+        item["spots_left"] = item.get("max_participants", 0) - len(item.get("participants", []))
+        items.append(item)
+
+    # Filtering
+    if q:
+        qlow = q.lower()
+        items = [it for it in items if qlow in it["name"].lower() or qlow in it.get("description", "").lower()]
+
+    if category:
+        items = [it for it in items if it.get("category") and it.get("category").lower() == category.lower()]
+
+    # Sorting
+    if sort == "spots":
+        items.sort(key=lambda x: x.get("spots_left", 0), reverse=True)
+    else:
+        items.sort(key=lambda x: x.get("name", ""))
+
+    # Pagination
+    total = len(items)
+    try:
+        page = max(1, int(page))
+    except Exception:
+        page = 1
+    try:
+        size = max(1, int(size))
+    except Exception:
+        size = 5
+    start = (page - 1) * size
+    end = start + size
+    paged = items[start:end]
+
+    return {"items": paged, "page": page, "size": size, "total": total}
+
+
+
+@app.get("/categories")
+def get_categories():
+    """Return a list of categories present in activities."""
+    cats = set()
+    for details in activities.values():
+        c = details.get("category")
+        if c:
+            cats.add(c)
+    return sorted(list(cats))
 
 
 @app.post("/activities/{activity_name}/signup")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -6,41 +6,47 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Function to fetch activities from API
   async function fetchActivities() {
+    const q = document.getElementById('search-q').value;
+    const category = document.getElementById('search-category').value;
+    const pageInfo = window._activity_page || { page: 1, size: 5 };
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (category) params.set('category', category);
+    params.set('page', pageInfo.page);
+    params.set('size', pageInfo.size);
+    const url = '/activities?' + params.toString();
     try {
-      const response = await fetch("/activities");
+      const response = await fetch(url);
       const activities = await response.json();
+      // support legacy format
+      const items = activities.items || Object.entries(activities).map(([name, details]) => ({ name, ...details }));
+      // store pagination info
+      window._activity_page = { page: activities.page || 1, size: activities.size || 5, total: activities.total || items.length };
 
       // Clear loading message
       activitiesList.innerHTML = "";
 
       // Populate activities list
-      Object.entries(activities).forEach(([name, details]) => {
+      items.forEach((details) => {
+        const name = details.name;
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - (details.participants || []).length;
 
-        // Create participants HTML with delete icons instead of bullet points
-        const participantsHTML =
-          details.participants.length > 0
-            ? `<div class="participants-section">
+        const participantsHTML = (details.participants || []).length > 0
+          ? `<div class="participants-section">
               <h5>Participants:</h5>
               <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
+                ${(details.participants || []).map((email) => `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`).join("")}
               </ul>
             </div>`
-            : `<p><em>No participants yet</em></p>`;
+          : `<p><em>No participants yet</em></p>`;
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
+          <p>${details.description || ''}</p>
+          <p><strong>Schedule:</strong> ${details.schedule || ''}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
           <div class="participants-container">
             ${participantsHTML}
@@ -49,12 +55,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
         activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
+        // Add option to select dropdown if not present
+        if (![...activitySelect.options].some(o => o.value === name)) {
+          const option = document.createElement("option");
+          option.value = name;
+          option.textContent = name;
+          activitySelect.appendChild(option);
+        }
       });
+
+      // Update pagination controls
+      const pageInfo = window._activity_page || { page: 1, size: 5, total: 0 };
+      const pageInfoSpan = document.getElementById('page-info');
+      const paginationControls = document.getElementById('pagination-controls');
+      if (pageInfoSpan) pageInfoSpan.textContent = `Page ${pageInfo.page} of ${Math.max(1, Math.ceil((pageInfo.total||0)/pageInfo.size))}`;
+      if (paginationControls) paginationControls.classList.remove('hidden');
+      document.getElementById('prev-page').disabled = pageInfo.page <= 1;
+      document.getElementById('next-page').disabled = pageInfo.page >= Math.ceil((pageInfo.total||0)/pageInfo.size);
 
       // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
@@ -64,6 +81,20 @@ document.addEventListener("DOMContentLoaded", () => {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
+    }
+  }
+
+  // Fetch categories and populate select
+  async function fetchCategories() {
+    try {
+      const resp = await fetch('/categories');
+      const cats = await resp.json();
+      const catSelect = document.getElementById('search-category');
+      cats.forEach(c => {
+        const opt = document.createElement('option'); opt.value = c; opt.textContent = c; catSelect.appendChild(opt);
+      });
+    } catch (e) {
+      console.error('Failed to load categories', e);
     }
   }
 
@@ -135,7 +166,7 @@ document.addEventListener("DOMContentLoaded", () => {
         signupForm.reset();
 
         // Refresh activities list to show updated participants
-        fetchActivities();
+          fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -156,5 +187,10 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
+  // Setup search controls
+  document.getElementById('search-btn').addEventListener('click', () => { window._activity_page = { page: 1, size: window._activity_page?.size || 5 }; fetchActivities(); });
+  document.getElementById('prev-page').addEventListener('click', () => { window._activity_page.page = Math.max(1, window._activity_page.page - 1); fetchActivities(); });
+  document.getElementById('next-page').addEventListener('click', () => { window._activity_page.page = window._activity_page.page + 1; fetchActivities(); });
+  fetchCategories();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -15,9 +15,24 @@
     <main>
       <section id="activities-container">
         <h3>Available Activities</h3>
+
+        <div id="search-controls">
+          <input type="search" id="search-q" placeholder="Search activities..." />
+          <select id="search-category">
+            <option value="">All categories</option>
+          </select>
+          <button id="search-btn">Search</button>
+        </div>
+
         <div id="activities-list">
           <!-- Activities will be loaded here -->
           <p>Loading activities...</p>
+        </div>
+
+        <div id="pagination-controls" class="hidden">
+          <button id="prev-page">Previous</button>
+          <span id="page-info"></span>
+          <button id="next-page">Next</button>
         </div>
       </section>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -57,6 +57,19 @@ section h3 {
   color: #1a237e;
 }
 
+#search-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+#pagination-controls {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
 .activity-card {
   margin-bottom: 15px;
   padding: 15px;


### PR DESCRIPTION
This PR adds a simple searchable, filterable and paginated /activities endpoint and a /categories endpoint. It also updates the static UI to include search controls, category selection and pagination.

Notes:
- Backend is still in-memory for MVP.
- Page size defaults to 5.
- Added `category` field to existing activities.